### PR TITLE
Containers for HPC workshop accessibility changes

### DIFF
--- a/content/courses/containers-for-hpc/building-apptainer.md
+++ b/content/courses/containers-for-hpc/building-apptainer.md
@@ -111,7 +111,7 @@ This is the very first entry. It defines the bootstrap agent:
 - `docker`
 - `library`
 - `shub`
-- and [many more](https://apptainer.org/docs/user/latest/definition_files.html#preferred-bootstrap-agents)
+- and [many more (opens in new tab)](https://apptainer.org/docs/user/latest/definition_files.html#preferred-bootstrap-agents)
 
 #### `From` (mandatory)
 Define the base container.
@@ -339,7 +339,7 @@ Save this as `lolcow_2.def`.
 - You may need to specify extra packages
     - `fortune` itself provides the executable without the message database
     - `fortunes-min` contains the message database
-- See [how Ubuntu reduced image size by 60%](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends)
+- See [how Ubuntu reduced image size by 60% (opens in new tab)](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends)
 
 ### Image size comparison
 
@@ -446,19 +446,19 @@ $ apptainer push lolcow_0.sif oras://myname/lolcow:0
 Check:
 `https://hub.docker.com/r/myname/lolcow/tags`
 
-{{< info >}}Best practice: Sign your containers; see [here](https://apptainer.org/docs/user/latest/signNverify.html).{{< /info >}}
+{{< info >}}Best practice: Sign your containers; see [Apptainer signing and verification documentation (opens in new tab)](https://apptainer.org/docs/user/latest/signNverify.html).{{< /info >}}
 
 {{< warning >}}While Apptainer can convert a Docker image into SIF, you cannot run SIF with Docker. You are simply using Docker Hub to host your SIF - it is not converted into Docker.{{< /warning >}}
 
 #### UVA Research Computing container resources
 
-[Docker Hub account](https://hub.docker.com/u/uvarc)
+[Docker Hub account (opens in new tab)](https://hub.docker.com/u/uvarc)
 
-[Repository of Dockerfiles and definition files](https://github.com/uvarc/rivanna-docker)
+[Repository of Dockerfiles and definition files (opens in new tab)](https://github.com/uvarc/rivanna-docker)
 
 ### GitHub Packages
 
-1. [Create a personal access token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)
+1. [Create a personal access token (opens in new tab)](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)
 1. Login
     ```bash
     apptainer remote login --username myname docker://ghcr.io
@@ -484,16 +484,16 @@ While you can create a conda environment locally, you cannot directly migrate it
 Your project requires PyTorch, Numpy, Seaborn, and Pandas. Write the corresponding Apptainer definition file.
 
 Hints:
-- Find the appropriate base image from [here](https://hub.docker.com/r/pytorch/pytorch/tags).
+- Find the appropriate base image from [PyTorch Docker image tags on Docker Hub (opens in new tab)](https://hub.docker.com/r/pytorch/pytorch/tags).
 - Pull the base image and examine it first. Does it already provide some packages?
 
 {{< info >}}While PyTorch runs on a GPU, you do not need to build the container on a GPU.{{< /info >}}
 
-{{< info >}}You will likely run out of memory when building large containers (over a few GBs). Request an [interactive job](https://www.rc.virginia.edu/userinfo/rivanna/slurm/#submitting-an-interactive-job) with say `--mem=50G` to build on a compute node with 50 GB memory.{{< /info >}}
+{{< info >}}You will likely run out of memory when building large containers (over a few GBs). Request an [interactive job (opens in new tab)](https://www.rc.virginia.edu/userinfo/rivanna/slurm/#submitting-an-interactive-job) with say `--mem=50G` to build on a compute node with 50 GB memory.{{< /info >}}
 
 ### R
 
-Rocker provides many base images for all R versions (see [here](https://rocker-project.org/images/)):
+Rocker provides many base images for all R versions (see [Rocker image catalog (opens in new tab)](https://rocker-project.org/images/)):
 - `rocker/r-ver`: basic R installation
 - `rocker/rstudio`: with RStudio Server
 - `rocker/tidyverse`: plus tidyverse and dependencies
@@ -512,14 +512,14 @@ Hints:
 
 ## Multistage Build
 
-By distinguishing between buildtime-dependencies vs runtime-dependencies, it is possible to reduce the image size drastically via a [multistage build](https://apptainer.org/docs/user/latest/definition_files.html#multi-stage-builds). (My experience with some extreme cases is that only 1% is needed at runtime.)
+By distinguishing between buildtime-dependencies vs runtime-dependencies, it is possible to reduce the image size drastically via a [multistage build (opens in new tab)](https://apptainer.org/docs/user/latest/definition_files.html#multi-stage-builds). (My experience with some extreme cases is that only 1% is needed at runtime.)
 
 This is beyond the scope of the workshop, but you are welcome to browse the Apptainer documentation and Appendix 2 on Minimal Containers.
 
 ---
 
 ## References
-- [Apptainer User Guide](https://apptainer.org/docs/user/latest)
-- [Definition File](https://apptainer.org/docs/user/latest/definition_files.html)
-- [Definition File vs Dockerfile](https://apptainer.org/docs/user/latest/docker_and_oci.html#apptainer-definition-file-vs-dockerfile)
-- [GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+- [Apptainer User Guide (opens in new tab)](https://apptainer.org/docs/user/latest)
+- [Definition File (opens in new tab)](https://apptainer.org/docs/user/latest/definition_files.html)
+- [Definition File vs Dockerfile (opens in new tab)](https://apptainer.org/docs/user/latest/docker_and_oci.html#apptainer-definition-file-vs-dockerfile)
+- [GitHub Packages (opens in new tab)](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)

--- a/content/courses/containers-for-hpc/building-docker.md
+++ b/content/courses/containers-for-hpc/building-docker.md
@@ -17,7 +17,7 @@ Starting from a simple Dockerfile, we will adopt best practices sequentially and
 
 2. Install Docker
 
-    To follow along on your own computer, please install Docker Desktop and register for a free account on Docker Hub. Both can be found [here](https://www.docker.com/get-started).
+    To follow along on your own computer, please install Docker Desktop and register for a free account on Docker Hub. Both are available from [Docker Get Started (opens in new tab)](https://www.docker.com/get-started).
 
     After the installation, open a terminal ("cmd" on Windows) and make sure you can execute the command `docker run hello-world` successfully.
 
@@ -34,7 +34,7 @@ Starting from a simple Dockerfile, we will adopt best practices sequentially and
 - Singularity
     - Users cannot build on Rivanna (needs `sudo` privilege)
     - Singularity Library/Hub (more limitations)
-    - Refer to [workshop](https://learning.rc.virginia.edu/workshops/singularity/) in Spring 2020
+    - Refer to [workshop (opens in new tab)](https://learning.rc.virginia.edu/workshops/singularity/) in Spring 2020
 
 ## Intro to Dockerfile: lolcow
 
@@ -61,7 +61,7 @@ FROM ubuntu:22.04
 - Doesn't have to be a bare OS
     - `python`, `continuumio/miniconda3`, `node`, `nvidia/cuda`, etc.
 
-[Dockerfile reference](https://docs.docker.com/engine/reference/builder/#format)
+[Dockerfile reference (opens in new tab)](https://docs.docker.com/engine/reference/builder/#format)
 
 ### Steps 2 & 3: Install software
 
@@ -233,14 +233,14 @@ ENTRYPOINT fortune | cowsay | lolcat
 - You may need to specify extra packages
     - `fortune` itself provides the executable without the message database
     - `fortunes-min` contains the message database
-- See [how Ubuntu reduced image size by 60%](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends)
+- See [how Ubuntu reduced image size by 60% (opens in new tab)](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends)
 
 ### 3. Use a smaller base image
 
 For installation of common packages, you may consider Alpine.
 
 - BusyBox + package manager + musl libc (beware of compatibility issues)
-- [Presentation](https://youtu.be/sIG2P9k6EjA) on Alpine Linux from DockerCon EU 17 
+- [Presentation (opens in new tab)](https://youtu.be/sIG2P9k6EjA) on Alpine Linux from DockerCon EU 17 
 
 Look for `slim` variants (e.g. `debian:buster-slim`) of a base image, if any.
 
@@ -277,7 +277,7 @@ $ docker images | grep lolcow | sort -nk 2 | awk '{print $1, $2, $NF}'
 |2  |Combination of previous two |53 | 26 |
 |3  |Alpine base image           |161| 78 |
 
-Reference: [_Best practices for writing Dockerfiles_](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
+Reference: [_Best practices for writing Dockerfiles_ (opens in new tab)](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
 
 ### Summary
 
@@ -309,7 +309,7 @@ In your browser, go to `https://hub.docker.com/r/<user>/lolcow`.
 
 - Overview: 
     - Sync with GitHub to update `README.md`; or
-    - Use [docker-pushrm](https://github.com/christian-korneck/docker-pushrm)
+    - Use [docker-pushrm (opens in new tab)](https://github.com/christian-korneck/docker-pushrm)
 - Tags:
     - List all versions
     - View image history if Dockerfile not provided
@@ -337,9 +337,9 @@ https://docs.qiime2.org/2022.8/install/native/#install-qiime-2-within-a-conda-en
 Hints:
 - Click on "Linux" to get the URL for the yaml file. Download the yaml file in the same directory as your Dockerfile.
 - You do not have to start from a bare OS in your Dockerfile. Search for `miniconda3` on Docker Hub.
-- (Recommended) There is a much faster dependency solver than conda - micromamba. See [here](https://micromamba-docker.readthedocs.io/en/latest/quick_start.html) for instructions.
+- (Recommended) There is a much faster dependency solver than conda - micromamba. See the [Micromamba Docker quick start guide (opens in new tab)](https://micromamba-docker.readthedocs.io/en/latest/quick_start.html) for instructions.
 - Use the suggested `COPY` and `ENTRYPOINT` statements.
-- After you're done, compare with the [official Dockerfile](https://github.com/qiime2/vm-playbooks/blob/0fda9dce42802596756986e2f80c38437872c66e/docker/Dockerfile) and image size. What is the biggest reason for the difference?
+- After you're done, compare with the [official Dockerfile (opens in new tab)](https://github.com/qiime2/vm-playbooks/blob/0fda9dce42802596756986e2f80c38437872c66e/docker/Dockerfile) and image size. What is the biggest reason for the difference?
 
 ### General Remarks
 
@@ -371,8 +371,8 @@ If you build containers often, you can run out of disk space quickly. To clean u
 
 ## References
 
-- [UVA Rivanna-Docker GitHub](https://github.com/uvarc/rivanna-docker)
+- [UVA Rivanna-Docker GitHub (opens in new tab)](https://github.com/uvarc/rivanna-docker)
     - Dockerfiles by UVA Research Computing
-    - [Tips](https://github.com/uvarc/rivanna-docker/wiki/Tips)
-- [_Best practices for writing Dockerfiles_](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
-- [Natanael Copa, _Small, Simple, and Secure: Alpine Linux under the Microscope_, DockerCon EU (2017)](https://youtu.be/sIG2P9k6EjA)
+    - [Tips (opens in new tab)](https://github.com/uvarc/rivanna-docker/wiki/Tips)
+- [_Best practices for writing Dockerfiles_ (opens in new tab)](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
+- [Natanael Copa, _Small, Simple, and Secure: Alpine Linux under the Microscope_, DockerCon EU (2017) (opens in new tab)](https://youtu.be/sIG2P9k6EjA)

--- a/content/courses/containers-for-hpc/minimal.md
+++ b/content/courses/containers-for-hpc/minimal.md
@@ -44,17 +44,17 @@ pip install --no-cache-dir ...
 ```
 
 ### 3. Base image
-- For OS and common tools (e.g. python/conda, GCC) start from [official image](https://docs.docker.com/docker-hub/official_images/)
+- For OS and common tools (e.g. python/conda, GCC) start from [official image (opens in new tab)](https://docs.docker.com/docker-hub/official_images/)
     - Do not reinvent the wheel
 - Know which variant to use (e.g. `devel` vs `runtime`, `slim`)
     - Read their overview
 
 ## Exercise: QIIME 2
-QIIME 2 is a popular bioinformatics software. Can you suggest any potential improvement to the [Dockerfile](https://github.com/qiime2/vm-playbooks/blob/0fda9dce42802596756986e2f80c38437872c66e/docker/Dockerfile)? 
+QIIME 2 is a popular bioinformatics software. Can you suggest any potential improvement to the [Dockerfile (opens in new tab)](https://github.com/qiime2/vm-playbooks/blob/0fda9dce42802596756986e2f80c38437872c66e/docker/Dockerfile)? 
 
 <details><summary>Answer</summary>
 
-With our [Dockerfile](https://github.com/uvarc/rivanna-docker/blob/master/qiime2/2020.8/Dockerfile), we managed to reduce the image size by half.
+With our [Dockerfile (opens in new tab)](https://github.com/uvarc/rivanna-docker/blob/master/qiime2/2020.8/Dockerfile), we managed to reduce the image size by half.
 
 </details>
 
@@ -80,7 +80,7 @@ The objective is to minimize image size without loss of functionality. What's ne
     - only install runtime dependencies (e.g. `cmake`, `go` not needed)
     - copy software from build stage
 
-Reference: [_Use multi-stage builds_](https://docs.docker.com/develop/develop-images/multistage-build/)
+Reference: [_Use multi-stage builds_ (opens in new tab)](https://docs.docker.com/develop/develop-images/multistage-build/)
 
 ### Multi-stage Dockerfile template
 
@@ -105,11 +105,11 @@ ENTRYPOINT ["binary"]
 ## Exercise: LightGBM
 LightGBM is a gradient boosting framework that uses tree based learning algorithms. It is an open source project by Microsoft.
 
-1. Examine the [official Dockerfile](https://github.com/microsoft/LightGBM/blob/master/docker/gpu/dockerfile.gpu). Can you identify any problems?
+1. Examine the [official Dockerfile (opens in new tab)](https://github.com/microsoft/LightGBM/blob/master/docker/gpu/dockerfile.gpu). Can you identify any problems?
 
     <details><summary>Answer</summary>
 
-    - `nvidia/cuda:cudnn-devel` as [base image](https://hub.docker.com/r/nvidia/cuda/tags)  (>1 GB)
+    - `nvidia/cuda:cudnn-devel` as [base image (opens in new tab)](https://hub.docker.com/r/nvidia/cuda/tags)  (>1 GB)
     - Clean up in separate `RUN` statements
 
     </details>
@@ -201,7 +201,7 @@ LightGBM is a gradient boosting framework that uses tree based learning algorith
     </details>
     <br>
 
-3. Rewrite the Dockerfile using a multi-stage build based on [OpenCL](https://hub.docker.com/r/nvidia/cuda/tags).
+3. Rewrite the Dockerfile using a multi-stage build based on [OpenCL (opens in new tab)](https://hub.docker.com/r/nvidia/cuda/tags).
     - Use `nvidia/opencl:devel` as the build stage
         - Remove everything related to CUDA since it is not relevant
         - Redefine the OpenCL environment variables as:
@@ -212,7 +212,7 @@ LightGBM is a gradient boosting framework that uses tree based learning algorith
         - Keep the same dependencies
         - Remember to clean up at the right place
         - Ignore the command under `# Add OpenCL ICD files for LightGBM`
-        - Instead of `mkdir foo && cd foo` use `WORKDIR foo` (see [documentation](https://docs.docker.com/engine/reference/builder/#workdir))
+        - Instead of `mkdir foo && cd foo` use `WORKDIR foo` (see [documentation (opens in new tab)](https://docs.docker.com/engine/reference/builder/#workdir))
         - Use the same command to install LightGBM, but replace the paths with the corresponding OpenCL environment variables
         - Add an `ENTRYPOINT`
     - Use `nvidia/opencl:runtime` as the production stage
@@ -270,7 +270,7 @@ LightGBM is a gradient boosting framework that uses tree based learning algorith
     </details>
     <br>
 
-4. Challenge: Verify that the two containers have the same performance on Rivanna's GPU node. Follow the [tutorial example](https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#dataset-preparation). Run the same job without using GPU. How much faster is it with GPU?
+4. Challenge: Verify that the two containers have the same performance on Rivanna's GPU node. Follow the [tutorial example (opens in new tab)](https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#dataset-preparation). Run the same job without using GPU. How much faster is it with GPU?
 
 ---
 
@@ -290,12 +290,12 @@ LightGBM is a gradient boosting framework that uses tree based learning algorith
     - Build production
 
 ### Example base images 
-- [Scratch](https://hub.docker.com/_/scratch)
+- [Scratch (opens in new tab)](https://hub.docker.com/_/scratch)
     - Literally start from scratch!
     - A "no-op" in the Dockerfile, meaning no extra layer in image
     - Build other base images (beyond scope of this workshop)
     - Minimal image with a single application
-- [Distroless](https://github.com/GoogleContainerTools/distroless)
+- [Distroless (opens in new tab)](https://github.com/GoogleContainerTools/distroless)
     - Derived from Debian
     - Support for C/C++, Go, Rust, Java, Node.js, Python
 
@@ -326,8 +326,8 @@ This exercise illustrates how we can cherry-pick files from the package manager 
     <br>
 
     For your reference, the content of the packages can be found here:
-    - fortune-mod [package list](https://packages.ubuntu.com/xenial/all/fortune-mod/filelist)
-    - fortunes-min [package list](https://packages.ubuntu.com/xenial/all/fortunes-min/filelist)
+    - fortune-mod [package list (opens in new tab)](https://packages.ubuntu.com/xenial/all/fortune-mod/filelist)
+    - fortunes-min [package list (opens in new tab)](https://packages.ubuntu.com/xenial/all/fortunes-min/filelist)
 
     <br>
 
@@ -439,7 +439,7 @@ The image size is merely **10.7 MB**, 99.5% smaller than what we started with. T
 
 </details>
 
-We submitted a [pull request](https://github.com/microsoft/LightGBM/pull/3408) that has been [merged](https://github.com/microsoft/LightGBM/tree/master/docker/gpu).
+We submitted a [LightGBM GPU Docker pull request (opens in new tab)](https://github.com/microsoft/LightGBM/pull/3408) that has been [merged into the LightGBM Docker GPU directory (opens in new tab)](https://github.com/microsoft/LightGBM/tree/master/docker/gpu).
 
 ---
 
@@ -449,23 +449,23 @@ TensorFlow is a popular platform for machine learning. It is an open source proj
 
 The TF 2.3 container that you used in the previous workshop is actually based on distroless, which is why you were not able to run `ls` inside the container.
 
-- [Dockerfile](https://github.com/uvarc/rivanna-docker/blob/master/tensorflow/2.3.0/Dockerfile.distroless)
+- [Dockerfile (opens in new tab)](https://github.com/uvarc/rivanna-docker/blob/master/tensorflow/2.3.0/Dockerfile.distroless)
 - 18% image size reduction
-- [PR](https://github.com/tensorflow/build/pull/13) approved and [merged](https://github.com/tensorflow/build)
+- [TensorFlow build pull request (opens in new tab)](https://github.com/tensorflow/build/pull/13) approved and [merged into the tensorflow/build repository (opens in new tab)](https://github.com/tensorflow/build)
 
 ---
 
 ## Dynamic vs Static Linking
 
-The above procedure, while impressive, may be tedious for the average user. All the examples so far are based on [dynamic linking](https://en.wikipedia.org/wiki/Dynamic_linker), where the shared libraries of an executable are stored separately. If you are compiling code from source, you may choose to build a static binary (e.g. `-static` in GCC) so that all the necessary libraries are built into the binary.
+The above procedure, while impressive, may be tedious for the average user. All the examples so far are based on [dynamic linking (opens in new tab)](https://en.wikipedia.org/wiki/Dynamic_linker), where the shared libraries of an executable are stored separately. If you are compiling code from source, you may choose to build a static binary (e.g. `-static` in GCC) so that all the necessary libraries are built into the binary.
 
 ## Exercise: Linking against OpenBLAS
 
-OpenBLAS is a linear algebra library. The code in this exercise is taken from its [user manual](https://github.com/xianyi/OpenBLAS/wiki/User-Manual#code-examples). It is based on `dgemm` which performs the matrix operation:
+OpenBLAS is a linear algebra library. The code in this exercise is taken from its [user manual (opens in new tab)](https://github.com/xianyi/OpenBLAS/wiki/User-Manual#code-examples). It is based on `dgemm` which performs the matrix operation:
 
 $$ \alpha A B + \beta C, $$
 
-where $A_{mk}, B_{kn}, C_{mn}$ are matrices and $\alpha, \beta$ are constants. For details please visit the [Intel tutorial page](https://software.intel.com/content/www/us/en/develop/documentation/mkl-tutorial-c/top/multiplying-matrices-using-dgemm.html).
+where $A_{mk}, B_{kn}, C_{mn}$ are matrices and $\alpha, \beta$ are constants. For details please visit the [Intel tutorial page (opens in new tab)](https://software.intel.com/content/www/us/en/develop/documentation/mkl-tutorial-c/top/multiplying-matrices-using-dgemm.html).
 
 1. Select an appropriate base image. (Hint: You will be compiling C++ code.)
 
@@ -576,7 +576,7 @@ where $A_{mk}, B_{kn}, C_{mn}$ are matrices and $\alpha, \beta$ are constants. F
 This exercise illustrates that it is easier to build a minimal container of a static binary.
 
 ## Exercise: Linking against LibTorch
-LibTorch is the C++ frontend of PyTorch. This exercise is based on the ["Writing a Basic Application"](https://pytorch.org/tutorials/advanced/cpp_frontend.html#writing-a-basic-application) section of the PyTorch tutorial.
+LibTorch is the C++ frontend of PyTorch. This exercise is based on the ["Writing a Basic Application" (opens in new tab)](https://pytorch.org/tutorials/advanced/cpp_frontend.html#writing-a-basic-application) section of the PyTorch tutorial.
 
 1. Select an appropriate base image. (Hint: You will be compiling C++ code.)
 
@@ -713,10 +713,10 @@ LibTorch is the C++ frontend of PyTorch. This exercise is based on the ["Writing
 
 ## References
 
-- [UVA Rivanna-Docker GitHub](https://github.com/uvarc/rivanna-docker)
+- [UVA Rivanna-Docker GitHub (opens in new tab)](https://github.com/uvarc/rivanna-docker)
     - Dockerfiles by UVA Research Computing
-    - [Tips](https://github.com/uvarc/rivanna-docker/wiki/Tips)
-- [_Best practices for writing Dockerfiles_](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
-- [_Use multi-stage builds_](https://docs.docker.com/develop/develop-images/multistage-build/)
-- [Google Distroless GitHub](https://github.com/GoogleContainerTools/distroless)
-- [Matthew Moore, _Distroless Docker: Containerizing Apps, not VMs_, swampUP (2017)](https://youtu.be/lviLZFciDv4)
+    - [Tips (opens in new tab)](https://github.com/uvarc/rivanna-docker/wiki/Tips)
+- [_Best practices for writing Dockerfiles_ (opens in new tab)](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
+- [_Use multi-stage builds_ (opens in new tab)](https://docs.docker.com/develop/develop-images/multistage-build/)
+- [Google Distroless GitHub (opens in new tab)](https://github.com/GoogleContainerTools/distroless)
+- [Matthew Moore, _Distroless Docker: Containerizing Apps, not VMs_, swampUP (2017) (opens in new tab)](https://youtu.be/lviLZFciDv4)

--- a/content/courses/containers-for-hpc/using.md
+++ b/content/courses/containers-for-hpc/using.md
@@ -30,7 +30,7 @@ To download a container hosted on a registry, use the `pull` command. Docker ima
 
 - `<URI>` (Unified resource identifiers)
     - `[library|docker|shub]://[<user>/]<repo>[:<tag>] `
-    - Default prefix: `library` ([Singularity Library](https://cloud.sylabs.io/library))
+    - Default prefix: `library` ([Singularity Library (opens in new tab)](https://cloud.sylabs.io/library))
     - `user`: optional; may be empty (e.g. `apptainer pull ubuntu`)
     - `tag`: optional; default: `latest`
 - `<SIF>` (Singularity image format)
@@ -246,7 +246,7 @@ sbatch tensorflow-2.17.0.slurm
 
 #### What does `--nv` do?
 
-See [Apptainer GPU user guide](https://apptainer.org/user-docs/master/gpu.html#nvidia-gpus-cuda-standard)
+See [Apptainer GPU user guide (opens in new tab)](https://apptainer.org/user-docs/master/gpu.html#nvidia-gpus-cuda-standard)
 
 ```bash
 $ apptainer shell $CONTAINERDIR/tensorflow-2.17.0.sif
@@ -271,7 +271,7 @@ Suppose you need to use TensorFlow 2.19.0 on JupyterLab. First, note we do not h
 module spider tensorflow
 ```
 
-Go to [TensorFlow's Docker Hub page](https://hub.docker.com/r/tensorflow/tensorflow) and search for the tag (i.e. version). You'll want to use one that has the `-gpu-jupyter` suffix. Pull the container in your account.
+Go to [TensorFlow's Docker Hub page (opens in new tab)](https://hub.docker.com/r/tensorflow/tensorflow) and search for the tag (i.e. version). You'll want to use one that has the `-gpu-jupyter` suffix. Pull the container in your account.
 
 ### Installation
 
@@ -348,6 +348,6 @@ rm -rf ~/.local/share/jupyter/kernels/tensorflow-2.19.0
 
 ## References
 
-- [Apptainer User Guide](https://apptainer.org/docs/user/latest/)
-    - [Overview](https://apptainer.org/docs/user/latest/quick_start.html)
-    - [Bind Path and Mounts](https://apptainer.org/docs/user/latest/bind_paths_and_mounts.html)
+- [Apptainer User Guide (opens in new tab)](https://apptainer.org/docs/user/latest/)
+    - [Apptainer quick start overview (opens in new tab)](https://apptainer.org/docs/user/latest/quick_start.html)
+    - [Bind Path and Mounts (opens in new tab)](https://apptainer.org/docs/user/latest/bind_paths_and_mounts.html)

--- a/content/courses/parallel-computing-introduction/distributed_mpi_cart_exercise.md
+++ b/content/courses/parallel-computing-introduction/distributed_mpi_cart_exercise.md
@@ -18,7 +18,7 @@ In the language of your choice, write a heated-plate solution using two-dimensio
 Check your rsults by plotting.  If you wish, you can use the script contour2d.py
 
 {{< spoiler >}}
-{{< code-download file=/courses/parallel-computing-introduction/scripts/contour2d.py" lang="python" >}}
+{{< code-download file="/courses/parallel-computing-introduction/scripts/contour2d.py" lang="python" >}}
 {{< /spoiler >}}
 
 The usage is

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,41 @@
+{{- define "main" -}}
+
+<div class="universal-wrapper pt-3">
+
+  <h1>{{ i18n "page_not_found" }}</h1>
+
+  {{/* Show search box if Academic's search engine is enabled. */}}
+  {{ if eq site.Params.search.engine 1 }}
+  <form role="search" class="d-flex align-items-center mb-3">
+      <label for="search-query-404" class="visually-hidden">{{ i18n "search" }}</label>
+    <input name="q"
+        id="search-query-404"
+           type="search"
+           class="form-control"
+           placeholder="{{ i18n "search_placeholder" }}"
+           aria-label="{{ i18n "search" }}"
+           autocapitalize="off"
+           autocomplete="off"
+           autocorrect="off"
+           spellcheck="false">
+    <button type="submit">{{ i18n "search" }}</button>
+  </form>
+  {{ end }}
+
+  {{/* Suggest recently published pages to the user. */}}
+  <p>{{ i18n "404_recommendations" }}</p>
+
+  {{ $query := site.RegularPages }}
+  {{ $count := len $query }}
+  {{ if gt $count 0 }}
+  <h2>{{ i18n "user_profile_latest" }}</h2>
+  <ul>
+    {{ range first 10 $query }}
+      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+  {{ end }}
+
+</div>
+
+{{- end -}}


### PR DESCRIPTION
Improves accessibility in the Containers for HPC course content by making link text more descriptive and indicating when links open in a new tab.

Changes:

- Replaced vague link text (e.g., “here”) with descriptive labels.
- Added “(opens in new tab)” to external links in Containers for HPC Markdown files.
- Included the related custom 404 page update.

Impact
Better link clarity and more predictable navigation for all users, including screen-reader and keyboard users.