### PR TITLE
Fix/pytorch broken images links

### DIFF
--- a/content/notes/pytorch-hpc/gpu.md
+++ b/content/notes/pytorch-hpc/gpu.md
@@ -22,7 +22,7 @@ Neural Networks can grow large and contain many million if not billions of param
 - **High memory bandwidth** for efficient data transfer
 - Optimized for **tensor operations** (e.g., matrix multiplications)
 
-If you’re working with a small model or smaller dataset, you may find using a GPU slows down your work.This is mainly due to the overhead cost of transfering data back and forward to the CPU. To find out if your task could benefit from using GPUs, it’s important to benchmark and profile your code. Learn more about Benchmarking and Profiling here: https://learning.rc.virginia.edu/notes/benchmark-parallel-programs/ https://learning.rc.virginia.edu/courses/python-high-performance/
+If you’re working with a small model or smaller dataset, you may find using a GPU slows down your work.This is mainly due to the overhead cost of transfering data back and forward to the CPU. To find out if your task could benefit from using GPUs, it’s important to benchmark and profile your code. Learn more about [Benchmarking and Profiling](https://learning.rc.virginia.edu/notes/benchmark-parallel-programs/) and [High-Performance Python](https://learning.rc.virginia.edu/courses/python-high-performance/).
 
 ---
 
@@ -95,6 +95,6 @@ sstat job_id
 Alternatively you can use the [SLURM Script Generator](https://www.rc.virginia.edu/userinfo/hpc/slurm-script-generator/) to create your script.
 
 
-For more information on SLURM visit: https://www.rc.virginia.edu/userinfo/hpc/software/pytorch/, https://www.rc.virginia.edu/userinfo/hpc/slurm/
+For more information on SLURM, visit [PyTorch on UVA HPC](https://www.rc.virginia.edu/userinfo/hpc/software/pytorch/) and [SLURM at UVA Research Computing](https://www.rc.virginia.edu/userinfo/hpc/slurm/).
 
-For information on multi-GPU use: https://pytorch.org/tutorials/beginner/ddp_series_multigpu.html
+For information on multi-GPU use, see the [PyTorch multi-GPU tutorial](https://pytorch.org/tutorials/beginner/ddp_series_multigpu.html).

--- a/content/notes/pytorch-hpc/overview.md
+++ b/content/notes/pytorch-hpc/overview.md
@@ -96,18 +96,18 @@ Activation functions introduce non-linearity into neural networks, enabling them
 <div class="container">
   <div class="row">
     <div class="col-md-6">
-      {{< figure src="/courses/pytorch-hpc/img/sigmoid.png" caption="Sigmoid" alt="Line graph of the Sigmoid activation function showing an S-shaped curve with output ranging from 0 to 1" width="400px" >}}
+      {{< figure src="/notes/pytorch-hpc/img/sigmoid.png" caption="Sigmoid" alt="Line graph of the Sigmoid activation function showing an S-shaped curve with output ranging from 0 to 1" width="400px" >}}
     </div>
     <div class="col-md-6">
-      {{< figure src="/courses/pytorch-hpc/img/tanh.png" caption="Tanh" alt="Line graph of the Tanh activation function showing an S-shaped curve with output ranging from -1 to 1" width="400px" >}}
+      {{< figure src="/notes/pytorch-hpc/img/tanh.png" caption="Tanh" alt="Line graph of the Tanh activation function showing an S-shaped curve with output ranging from -1 to 1" width="400px" >}}
     </div>
   </div>
   <div class="row">
     <div class="col-md-6">
-      {{< figure src="/courses/pytorch-hpc/img/relu.png" caption="ReLU" alt="Line graph of the ReLU activation function showing zero output for negative inputs and a linear increase for positive inputs" width="400px" >}}
+      {{< figure src="/notes/pytorch-hpc/img/relu.png" caption="ReLU" alt="Line graph of the ReLU activation function showing zero output for negative inputs and a linear increase for positive inputs" width="400px" >}}
     </div>
     <div class="col-md-6">
-      {{< figure src="/courses/pytorch-hpc/img/leakyrelu.png" caption="Leaky ReLU" alt="Line graph of the Leaky ReLU activation function showing a small negative slope for negative inputs and a linear increase for positive inputs" width="400px" >}}
+      {{< figure src="/notes/pytorch-hpc/img/leakyrelu.png" caption="Leaky ReLU" alt="Line graph of the Leaky ReLU activation function showing a small negative slope for negative inputs and a linear increase for positive inputs" width="400px" >}}
     </div>
   </div>
 </div>

--- a/content/notes/pytorch-hpc/project.md
+++ b/content/notes/pytorch-hpc/project.md
@@ -35,7 +35,7 @@ pytorch_project/
 Tracking experiments is essential for understanding model performance.
 
 Using TensorBoard for Monitoring
-TensorBoard is Tensorflow's visualization toolkit. It is compatible with PyTorch and enbles you to keep track of your experiments' metrics like lossand accuracy and easily visualize them. For more information visit: https://www.tensorflow.org/tensorboard
+TensorBoard is Tensorflow's visualization toolkit. It is compatible with PyTorch and enbles you to keep track of your experiments' metrics like lossand accuracy and easily visualize them. For more information, visit the [TensorBoard documentation](https://www.tensorflow.org/tensorboard).
 ```python
 from torch.utils.tensorboard import SummaryWriter
 


### PR DESCRIPTION
Fixes broken PyTorch images by correcting paths and replaces bare URLs with descriptive link text for accessibility.