### PR TITLE
added alt-text for images in Introduction to Bioinformatic Tools for HPC and Working with Genomic Data on HPC

### DIFF
--- a/content/notes/bioinfo-intro/04-databases.md
+++ b/content/notes/bioinfo-intro/04-databases.md
@@ -10,7 +10,7 @@ menu:
 
 **InterPro**
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_8.png width=45% height=45% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_8.png alt="InterPro and Pfam database page screenshot" caption="InterPro entry for Pfam" width=45% height=45% >}}
 
 
 [https://www.ebi.ac.uk/interpro/entry/pfam](https://www.ebi.ac.uk/interpro/entry/pfam)
@@ -19,7 +19,7 @@ menu:
 
 **National Library of Medicine** 
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_9.png width=45% height=45% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_9.png alt="National Library of Medicine and NCBI homepage screenshot" caption="NCBI homepage" width=45% height=45% >}}
 
 
 [https://www.ncbi.nlm.nih.gov](https://www.ncbi.nlm.nih.gov)
@@ -28,7 +28,7 @@ menu:
 
 **Ensembl** 
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_11.png width=45% height=45% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_11.png alt="Ensembl genome browser homepage screenshot" caption="Ensembl homepage" width=45% height=45% >}}
 
 
 [https://www.ensembl.org/index.html](https://www.ensembl.org/index.html)
@@ -37,7 +37,7 @@ menu:
 
 **Fang**
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_10.png width=45% height=45% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_10.png alt="FAANG data portal homepage screenshot" caption="FAANG data portal" width=45% height=45% >}}
 
 
 [https://data.faang.org/home](https://data.faang.org/home)
@@ -46,7 +46,7 @@ menu:
 
 **EMBL-EBI**
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_13.png width=65% height=65% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_13.png alt="EMBL-EBI homepage screenshot" caption="EMBL-EBI homepage" width=65% height=65% >}}
 
 
 [https://www.ebi.ac.uk](https://www.ebi.ac.uk)
@@ -55,7 +55,7 @@ menu:
 
 **RGD**
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_12.png width=75% height=75% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_12.png alt="Rat Genome Database website screenshot" caption="Rat Genome Database homepage" width=75% height=75% >}}
 
 
 [https://rgd.mcw.edu](https://rgd.mcw.edu)

--- a/content/notes/bioinfo-intro/06-pacbio.md
+++ b/content/notes/bioinfo-intro/06-pacbio.md
@@ -10,7 +10,7 @@ menu:
 
 The below figure compares how the different sequencing technologies map reads to the STRC gene.
 
-{{< figure src=/notes/bioinfo-intro/img/pacbio.png width=90% height=90% >}}
+{{< figure src=/notes/bioinfo-intro/img/pacbio.png alt="Comparison of sequencing read mapping across technologies at the STRC gene" caption="Read mapping comparison for the STRC gene across sequencing technologies" width=90% height=90% >}}
 
 This shows how PacBio produces reads that are both long and accurate.
 

--- a/content/notes/bioinfo-intro/07-fileformats.md
+++ b/content/notes/bioinfo-intro/07-fileformats.md
@@ -8,7 +8,7 @@ menu:
         parent: Bioinformatics
 ---
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_16.png caption="Source: https://xkcd.com/927/" width=80% height=80% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_16.png alt="xkcd comic about competing file format standards" caption="Source: https://xkcd.com/927/" width=80% height=80% >}}
 
 The format name usually denotes the file suffix. 
 
@@ -26,7 +26,7 @@ The format name usually denotes the file suffix.
   
 ### FASTA Format 
 
-A FASTA file begins with a header line, indicated by the `>` symbol, that contains an identifier and optional description The following lines contain the biological sequence itself.
+A FASTA file begins with a header line, indicated by the `>` symbol, that contains an identifier and optional description. The following lines contain the biological sequence itself.
 
 
 <span style="color:#ff0000"> __>__ </span> NP_000552.2 Human glutathione transferase M1 (GSTM1) ```

--- a/content/notes/bioinfo-intro/08-qualityscores.md
+++ b/content/notes/bioinfo-intro/08-qualityscores.md
@@ -20,7 +20,7 @@ $$
 
 `P` represents the probability of base call being wrong
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_21.png caption="Table source: https://www.illumina.com/Documents/products/technotes/technote_Q-Scores.pdf " width=90% height=90% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_21.png alt="Table showing Phred quality scores and corresponding base call error probabilities" caption="Table source: https://www.illumina.com/Documents/products/technotes/technote_Q-Scores.pdf " width=90% height=90% >}}
 
 While next-generation sequencing metrics vary from those of Sanger sequencing (e.g., no electropherogram peak heights), the process of generating a Phred quality scoring scheme is largely the same. 
 

--- a/content/notes/bioinfo-intro/10-fastqc-qualityreads.md
+++ b/content/notes/bioinfo-intro/10-fastqc-qualityreads.md
@@ -12,10 +12,10 @@ FASTQC provides an overview of sequencing read quality.
 
 Sample FASTQC reports displaying varying metrics: 
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_24.png width=85% height=85% caption="FASTQC report showing per-base sequence quality, with most bases maintaining high quality across reads and slight drops at the read ends typical of Illumina data." >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_24.png alt="FASTQC per-base sequence quality plot with generally high quality and a slight decline at read ends" width=85% height=85% caption="FASTQC report showing per-base sequence quality, with most bases maintaining high quality across reads and slight drops at the read ends typical of Illumina data." >}}
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_25.png width=85% height=85% caption="FASTQC report showing per-base sequence quality, where read quality declines toward the end, indicating potential sequencing degradation or lower confidence in base calls at later positions." >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_25.png alt="FASTQC per-base sequence quality plot with decreasing quality toward later read positions" width=85% height=85% caption="FASTQC report showing per-base sequence quality, where read quality declines toward the end, indicating potential sequencing degradation or lower confidence in base calls at later positions." >}}
 
-{{< figure src=/notes/bioinfo-intro/img/readq3.png width=85% height=85% caption="FASTQC report showing a decline in per-base sequence quality toward the end of reads, indicating significant quality drop-off and potential sequencing errors in later positions." >}}
+{{< figure src=/notes/bioinfo-intro/img/readq3.png alt="FASTQC per-base sequence quality plot with pronounced quality drop-off near read ends" width=85% height=85% caption="FASTQC report showing a decline in per-base sequence quality toward the end of reads, indicating significant quality drop-off and potential sequencing errors in later positions." >}}
 
 [Read More](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)

--- a/content/notes/bioinfo-intro/16-interactive.md
+++ b/content/notes/bioinfo-intro/16-interactive.md
@@ -50,8 +50,8 @@ Notes:
 
 The above command produces `.html` reports. 
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_34.png caption="Job output - Quality Scores" width=70% height=70% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_34.png alt="FASTQC HTML report output showing quality score results" caption="Job output - Quality Scores" width=70% height=70% >}}
 
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_36.png caption="Job output - Adapter Content. The red X indicates that adapter contamination is detected." width=80% height=80% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_36.png alt="FASTQC adapter content output with a failure flag indicating adapter contamination" caption="Job output - Adapter Content. The red X indicates that adapter contamination is detected." width=80% height=80% >}}
 

--- a/content/notes/bioinfo-intro/17-slurmscript.md
+++ b/content/notes/bioinfo-intro/17-slurmscript.md
@@ -45,7 +45,7 @@ Job started:
 
  Job ended:
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_38.png width=75% height=75% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_38.png alt="Terminal output showing a Slurm FASTQC job completion message" caption="Slurm job completion output" width=75% height=75% >}}
 
 ### Operational Terminal Commands
 

--- a/content/notes/bioinfo-intro/19-trimming-sequences.md
+++ b/content/notes/bioinfo-intro/19-trimming-sequences.md
@@ -11,7 +11,7 @@ menu:
 
 Before aligning sequencing reads, it’s important to remove adapter sequences and low-quality bases.
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_44.png caption="Illumina documentation listing adapter and primer sequences commonly trimmed from raw reads." width=80% height=80% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_44.png alt="Table of Illumina adapter and primer sequences used for trimming" caption="Illumina documentation listing adapter and primer sequences commonly trimmed from raw reads." width=80% height=80% >}}
 
 [Read more about Illumina adapter sequences](https://support-docs.illumina.com/SHARE/AdapterSequences/Content/SHARE/AdapterSeq/Nextera/SequencesNextera_Illumina.htm)
 
@@ -24,7 +24,7 @@ Essentially, Cutadapt trims adapters from short read Illumina data.
 
 [Documentation](https://cutadapt.readthedocs.io/en/stable/)
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_42.png width=85% height=85% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_42.png alt="FASTQC adapter content output indicating adapter contamination in reads" caption="FASTQC report showing adapter content before trimming" width=85% height=85% >}}
 
 The above image shows a FASTQC `.html` report indicating that adapter sequences are still present in the reads. In this case, you would use **Cutadapt** to trim the adapters. 
 
@@ -95,10 +95,10 @@ $ fastqc -t 4 -o fastqc-out-trimmed  ecoli-fastq/SRR2584866-trimmed_1.fastq
 
 Before trimming: 
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_49.png width=70% height=70% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_49.png alt="FASTQC adapter content output before trimming showing contamination" caption="Before trimming" width=70% height=70% >}}
 
 After trimming:
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_51.png width=70% height=70% >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_51.png alt="FASTQC adapter content output after trimming showing improved results" caption="After trimming" width=70% height=70% >}}
 
 As you can see, adapter sequences have been successfully removed.

--- a/content/notes/bioinfo-intro/22-bowtie2.md
+++ b/content/notes/bioinfo-intro/22-bowtie2.md
@@ -10,7 +10,7 @@ menu:
 
 After trimming adapters and low-quality sequences with Cutadapt, the next step is to align the cleaned reads to a reference genome using Bowtie2.
 
-{{< figure src=/notes/bioinfo-intro/img/bowtie.png width=75% height=75% caption="After alignment with tools such as Bowtie2, the mapped reads can be visualized to assess coverage, variants, and alignment quality across sequencing platforms." >}}
+{{< figure src=/notes/bioinfo-intro/img/bowtie.png alt="Mapped sequencing reads displayed along a reference genome after Bowtie2 alignment" width=75% height=75% caption="After alignment with tools such as Bowtie2, the mapped reads can be visualized to assess coverage, variants, and alignment quality across sequencing platforms." >}}
 
 Alignment is often the time-limiting step. 
 
@@ -20,13 +20,13 @@ __End-to-end alignment example__
 
 The following is an "end-to-end" alignment because it involves all the characters in the read (default).
 
-{{< figure src=/notes/bioinfo-intro/img/bowtieexample.png width=60% height=60% >}}
+{{< figure src=/notes/bioinfo-intro/img/bowtieexample.png alt="Diagram illustrating end-to-end alignment where the full read aligns" caption="End-to-end alignment example" width=60% height=60% >}}
 
 __Local alignment example__
 
 The following is a "local" alignment because some of the characters at the ends of the read do not participate. In this case, 4 characters are omitted (or "soft trimmed" or "soft clipped") from the beginning and 3 characters are omitted from the end.
 
-{{< figure src=/notes/bioinfo-intro/img/read2bowtie.png width=60% height=60% >}}
+{{< figure src=/notes/bioinfo-intro/img/read2bowtie.png alt="Diagram illustrating local alignment with soft-clipped bases at read ends" caption="Local alignment example" width=60% height=60% >}}
 
 [Bowtie2 Documentation](https://bowtie-bio.sourceforge.net/bowtie2/index.shtml)
 

--- a/content/notes/bioinfo-intro/25-smrtlink.md
+++ b/content/notes/bioinfo-intro/25-smrtlink.md
@@ -25,7 +25,7 @@ Lots of tools are available for sequence analysis and data manipulation.
 For example, `bam2fasta` converts `BAM` to `FASTA`, and `bam2fastq` converts `BAM` to `FASTQ`.
 
 
-{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_67.png width=90% height=90% caption="PacBio Revio sequencing instrument interface" >}}
+{{< figure src=/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_67.png alt="PacBio Revio sequencing instrument software interface screen" width=90% height=90% caption="PacBio Revio sequencing instrument interface" >}}
 
 [SMRT Tools Reference Guide](https://docslib.org/doc/175362/smrt%C2%AE-tools-reference-guide-v8-0)
 

--- a/content/notes/bioinfo-intro/26-future-directions.md
+++ b/content/notes/bioinfo-intro/26-future-directions.md
@@ -14,15 +14,15 @@ These developments suggest a shift toward intelligent systems that can interpret
 Recent Work:
 
 
-{{< figure src="/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_68.png" caption="**DrBioRight 2.0:** An LLM-powered bioinformatics chatbot for large-scale cancer functional proteomics analysis (Nature Communications, 2025)." width=80% height=80% >}}
+{{< figure src="/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_68.png" alt="Screenshot of DrBioRight 2.0 paper on an LLM-powered bioinformatics chatbot for cancer proteomics" caption="**DrBioRight 2.0:** An LLM-powered bioinformatics chatbot for large-scale cancer functional proteomics analysis (Nature Communications, 2025)." width=80% height=80% >}}
 
-{{< figure src="/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_69.png" caption="**Review:** Deep learning applications in human genomics using next-generation sequencing data (Human Genomics, 2022)." width=90% height=90% >}}
+{{< figure src="/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_69.png" alt="Screenshot of review article on deep learning applications in human genomics" caption="**Review:** Deep learning applications in human genomics using next-generation sequencing data (Human Genomics, 2022)." width=90% height=90% >}}
 
-{{< figure src="/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_70.png" caption="**Perspective:** Advancing bioinformatics with large language models — components, applications, and future outlook (Computational and Structural Biotechnology Journal)." width=90% height=90% >}}
+{{< figure src="/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_70.png" alt="Screenshot of perspective article on using large language models in bioinformatics" caption="**Perspective:** Advancing bioinformatics with large language models — components, applications, and future outlook (Computational and Structural Biotechnology Journal)." width=90% height=90% >}}
 
-{{< figure src="/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_71.png" caption="**Editorial:** Large language models and their applications in bioinformatics (Nature Portfolio, 2023)." width=95% height=95% >}}
+{{< figure src="/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_71.png" alt="Screenshot of editorial about large language model applications in bioinformatics" caption="**Editorial:** Large language models and their applications in bioinformatics (Nature Portfolio, 2023)." width=95% height=95% >}}
 
-{{< figure src="/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_72.png" caption="**Collection:** Artificial intelligence in genomics (Nature, 2023)." width=95% height=95% >}}
+{{< figure src="/notes/bioinfo-intro/img/Intro-Bioinformatics-for-posting_20250604_72.png" alt="Screenshot of Nature collection page on artificial intelligence in genomics" caption="**Collection:** Artificial intelligence in genomics (Nature, 2023)." width=95% height=95% >}}
 
 
 

--- a/content/notes/genomics/1-history.md
+++ b/content/notes/genomics/1-history.md
@@ -9,7 +9,7 @@ menu:
 
 ## Significant Milestones
 
-{{< figure src="/notes/genomics/img/timeline.jpg" width=70% height=70% caption="Giani et al. 2020" >}}
+{{< figure src="/notes/genomics/img/timeline.jpg" alt="Timeline of key milestones in genome assembly history" width=70% height=70% caption="Giani et al. 2020" >}}
 
 __1977__ - Sanger et al. assemble the first complete genome (5375 bp) of an organism, specifically a bacteriophage.
 
@@ -21,15 +21,15 @@ __2000__ - Myers et al. assemble the _Drosophila melanogaster_ (fruit fly) genom
 
 There are many more sequencing projects involving a diverse variety of living organisms.
 
-{{< figure src="/notes/genomics/img/lab.jpg" width=40% height=40% >}}
+{{< figure src="/notes/genomics/img/lab.jpg" alt="Historic genome sequencing laboratory environment" caption="Genome sequencing lab setting" width=40% height=40% >}}
 
 ### The Human Genome Project
 
 There were both public and private efforts to complete the human genome sequence. In 1990, The Department of Energy and the National Institutes of Health began funding a $3 billion project to assemble the human genome from millions of small DNA fragments. The project was officially announced as complete in 2003. In 1998, Craig Venter and his company Celera Genomics began a privately funded effort to sequence the human genome, costing about 300 million dollars. Later on, the courts established that human genes could not be patented.
 
-{{< figure src="/notes/genomics/img/naturemag.png" width=20% height=30% >}}
+{{< figure src="/notes/genomics/img/naturemag.png" alt="Nature magazine cover related to human genome sequencing" caption="Nature coverage of the human genome" width=20% height=30% >}}
 
-{{< figure src="/notes/genomics/img/sciencemag.png" width=20% height=30% >}}
+{{< figure src="/notes/genomics/img/sciencemag.png" alt="Science magazine cover related to human genome sequencing" caption="Science coverage of the human genome" width=20% height=30% >}}
 
 Though the Human Genome project was "completed" in 2003, the project was actually only 99% finished, with the remaining 1% consisting of highly repetitive DNA (heterochromatic regions, centromeres, telomeres, tandem duplications) that was difficult to assemble with the technology at the time. Later, advancements in technology were able to produce longer reads, making the sequencing of highly repetitive DNA much easier. Crucial technological advancements included:
 
@@ -46,7 +46,7 @@ Technologies like Nanopore and PacBio were able to produce complete long reads, 
 
 As a result of these new technologies, the human genome was able to be sequenced from telomere to telomere. Previously unresolvable regions like centromeres could now be successfully assembled, and previous gaps on the genome were filled. Technology has improved so much that in 2023, scientists were able to fully sequence a human Y chromosome (known to contain an extremely high proportion of repetitive DNA sequences).
 
-{{< figure src="/notes/genomics/img/sciencemag2.jpg" width=30% height=30% >}}
+{{< figure src="/notes/genomics/img/sciencemag2.jpg" alt="Science article image highlighting telomere-to-telomere genome completion" caption="Telomere-to-telomere genome milestone" width=30% height=30% >}}
 
 ## Genome Assembly
 
@@ -60,10 +60,10 @@ Reads can be broken down further into __k-mers__ (substrings of length k), and t
 
 The reads are then arranged in a graph (often a de Bruijn graph) so that the path through the graph represents the assembled sequence. The path should explain every read while maximizing overlaps.
 
-{{< figure src="/notes/genomics/img/layout.png" width=60% height=60% >}}
+{{< figure src="/notes/genomics/img/layout.png" alt="Diagram of genome assembly layout step using graph structure" caption="Genome assembly layout step" width=60% height=60% >}}
 
 ### Consensus
 
 All the assembled sequences are then compared to one another. If there are different nucleotides at a certain position, the most frequent nucleotide is used to reach a consensus. This helps to correct errors that might have occurred earlier during the sequencing process, producing a final DNA sequence.
 
-{{< figure src="/notes/genomics/img/consensus.png" width=40% height=40% >}}
+{{< figure src="/notes/genomics/img/consensus.png" alt="Diagram illustrating consensus sequence generation from multiple reads" caption="Genome assembly consensus step" width=40% height=40% >}}

--- a/content/notes/genomics/2-construction.md
+++ b/content/notes/genomics/2-construction.md
@@ -9,13 +9,13 @@ menu:
 
 The construction of a sequence begins with __short-insert sequence reads__. These short reads are then combined to form longer, contiguous sequences called __contigs__. Contigs are then combined to form even larger __scaffolds__, though there often gaps between the contigs where the sequence is unknown. __Long-read sequencing__ technologies can help order contigs in a sequence, as well as estimate the size of gaps (represented by the string of `N`s).
 
-{{< figure src="/notes/genomics/img/construction.png" width=60% height=60% >}}
+{{< figure src="/notes/genomics/img/construction.png" alt="Diagram showing short-read genome assembly construction" caption="Genome assembly construction with short reads" width=60% height=60% >}}
 
 ## Assembly Construction - Long Reads
 
 The assembly construction for long reads is still hierarchical, but proceeds in two rounds. The first round of assembly involves the selection of __seed reads__, or the longest reads in the dataset (with a user-defined length cutoff). In the second round, all shorter reads are aligned to the seed reads, in order to generate consensus sequences with high accuracy. We refer to these as __pre-assembled reads__, but they can also be thought of as “error corrected” reads. During the pre-assembly process, seed reads may be split or trimmed at regions of low read coverage (with a user-defined _min cov_ for FALCON sense option). The performance of the pre-assembly process is captured in the pre-assembly stats file.
 
-{{< figure src="/notes/genomics/img/constructionlong.png" width=60% height=60% >}}
+{{< figure src="/notes/genomics/img/constructionlong.png" alt="Diagram showing long-read genome assembly construction" caption="Genome assembly construction with long reads" width=60% height=60% >}}
 
 ## Repetitive Regions
 

--- a/content/notes/genomics/3-technologies.md
+++ b/content/notes/genomics/3-technologies.md
@@ -18,37 +18,37 @@ There are many sequencing technologies in the field of DNA sequencing. Some of t
 
 PacBio produces long reads typically around 25kb, with a 99.9% read quality (Q30), which is better than some short-read contigs. PacBio HiFi reads also distinguish repeats rather than spanning full repeats. However, their reads are limited in length and have lower throughput than Nanopore.
 
-{{< figure src="/notes/genomics/img/pacbio.jpg" width=100% height=100% >}}
+{{< figure src="/notes/genomics/img/pacbio.jpg" alt="PacBio long-read sequencing overview illustration" caption="PacBio sequencing technology overview" width=100% height=100% >}}
 
 ### Phased Genome Assemblies
 
 Standard assemblies produce __unphased__ sequences, where the variation from two chromosomes is collapsed into a __pseudo-haplotype__ (a single, mixed sequence). PacBio assemblies allow for the production of __phased__ sequences, where the variation from two chromosomes is preserved in two separate sequences.
 
-{{< figure src="/notes/genomics/img/phased1.jpg" width=50% height=50% >}}
+{{< figure src="/notes/genomics/img/phased1.jpg" alt="Phased assembly concept illustration part one" caption="Phased assembly concept" width=50% height=50% >}}
 
-{{< figure src="/notes/genomics/img/phased2.png" width=70% height=70% >}}
+{{< figure src="/notes/genomics/img/phased2.png" alt="Phased assembly concept illustration part two" caption="Phased assembly example" width=70% height=70% >}}
 
 ## Nanopore Sequencing
 
-{{< figure src="/notes/genomics/img/nanopore.jpg" width=40% height=40% >}}
+{{< figure src="/notes/genomics/img/nanopore.jpg" alt="Oxford Nanopore sequencing workflow illustration" caption="Nanopore sequencing workflow" width=40% height=40% >}}
 
 Nanopore is able to produce “ultra-long” reads up to 4 Mb. Its accuracy is at about 95% read quality, and it is able to span repeat regions. The quality is limited compared to other technologies, and it has taken a while for Nanopore's technology to reach where it is today.
 
-{{< figure src="/notes/genomics/img/nanoporedevice.jpg" width=50% height=50% caption="A sample-to-sequence portable Nanopore device" >}}
+{{< figure src="/notes/genomics/img/nanoporedevice.jpg" alt="Portable sample-to-sequence Nanopore device" width=50% height=50% caption="A sample-to-sequence portable Nanopore device" >}}
 
-{{< figure src="/notes/genomics/img/katerubins.png" width=40% height=40% caption="Kate Rubins using Nanopore on the ISS" >}}
+{{< figure src="/notes/genomics/img/katerubins.png" alt="Astronaut Kate Rubins using Nanopore sequencing on the ISS" width=40% height=40% caption="Kate Rubins using Nanopore on the ISS" >}}
 
 Nanopore uses long reads and coverage to detect repeats.
 
-{{< figure src="/notes/genomics/img/nanoporerepeat.png" width=50% height=50% >}}
+{{< figure src="/notes/genomics/img/nanoporerepeat.png" alt="Nanopore reads spanning repetitive genomic regions" caption="Nanopore sequencing in repetitive regions" width=50% height=50% >}}
 
 ## Hi-C
 
 Hi-C is a genomic technique used to capture chromatin information. It involves detecting and analyzing the frequency of contacts between regions of DNA, in order to determine the correct order and orientation of the DNA segments. For example, segments with more contact are likely to be adjacent or closer to each other.
 
-{{< figure src="/notes/genomics/img/hic1.png" width=90% height=90% >}}
+{{< figure src="/notes/genomics/img/hic1.png" alt="Hi-C contact map example showing chromatin interactions" caption="Hi-C contact map example" width=90% height=90% >}}
 
-{{< figure src="/notes/genomics/img/hic2.png" width=100% height=100% >}}
+{{< figure src="/notes/genomics/img/hic2.png" alt="Hi-C based scaffolding and genome organization diagram" caption="Hi-C scaffolding overview" width=100% height=100% >}}
 
 ## References
 

--- a/content/notes/genomics/4-formats.md
+++ b/content/notes/genomics/4-formats.md
@@ -7,7 +7,7 @@ menu:
     genomics:
 ---
 
-{{< figure src="/notes/genomics/img/comic.png" width=50% height=50% caption="http://xkcd.com/927/" >}}
+{{< figure src="/notes/genomics/img/comic.png" alt="xkcd comic about standards and file formats" width=50% height=50% caption="http://xkcd.com/927/" >}}
 
 
 There are many different file formats that can be used for storing info about DNA sequences. With file formats, the format name usually denotes the suffix as well.
@@ -27,15 +27,15 @@ There are many different file formats that can be used for storing info about DN
 
 Here is an example of what a FASTA file looks like after the first time an assembly is opened.
 
-{{< figure src="/notes/genomics/img/fasta.png" width=70% height=70% >}}
+{{< figure src="/notes/genomics/img/fasta.png" alt="Annotated example showing the structure of a FASTA file" caption="Example FASTA format structure" width=70% height=70% >}}
 
 ## FASTQ
 
 Most modern sequencing platforms perform base calling and then return that data in FASTQ format, with quality scores included. (These quality scores are encoded using ASCII characters.) The FASTQ data can then be used for quality control and trimming.
 
-{{< figure src="/notes/genomics/img/fastq1.png" width=70% height=70% caption="The basic structure of a FASTQ file" >}}
+{{< figure src="/notes/genomics/img/fastq1.png" alt="Diagram showing the basic structure of a FASTQ record" width=70% height=70% caption="The basic structure of a FASTQ file" >}}
 
-{{< figure src="/notes/genomics/img/fastq2.png" width=70% height=70% caption="An example of a FASTQ file with multiple sequencing reads" >}}
+{{< figure src="/notes/genomics/img/fastq2.png" alt="Example FASTQ file containing multiple sequencing reads" width=70% height=70% caption="An example of a FASTQ file with multiple sequencing reads" >}}
 
 ## SAM/BAM
 
@@ -45,7 +45,7 @@ Both SAM (Sequence Alignment Map) and BAM are file formats for sequence alignmen
 
 GTF (Gene Transfer Format) is a common format for annotating gene info on a genome.
 
-{{< figure src="/notes/genomics/img/gtf.png" width=100% height=100% caption="An example of a GTF file" >}}
+{{< figure src="/notes/genomics/img/gtf.png" alt="Example of genome annotation entries in GTF format" width=100% height=100% caption="An example of a GTF file" >}}
 
 ## References
 

--- a/content/notes/genomics/5-genomes.md
+++ b/content/notes/genomics/5-genomes.md
@@ -25,12 +25,12 @@ There are a wide variety of public, online databases that store reference genome
 
 As sequencing technology advances, the shift in the field is moving from single genome assembly to __pangenomes__ (collections of all genes and sequences found within a species or broader group). Pangenomes are constructed from many resources, such as the reference sequence, variant sequences, raw reads, and haplotype reference panels.
 
-{{< figure src="/notes/genomics/img/pangenome.png" width=70% height=70% caption="Examples of large-scale pangenome projects" >}}
+{{< figure src="/notes/genomics/img/pangenome.png" alt="Examples of large-scale pangenome projects across species" width=70% height=70% caption="Examples of large-scale pangenome projects" >}}
 
 In the example research paper below, researchers constructed a pangenome for soybeans. The researchers performed 26 new genome assemblies and incorporated 3 previously reported assemblies. Through their pangenome, the researchers were able to search for variants that would have been undetectable in a single reference genome.
 
-{{< figure src="/notes/genomics/img/soybeans.png" width=70% height=70% caption="https://doi.org/10.1016/j.cell.2020.05.023" >}}
+{{< figure src="/notes/genomics/img/soybeans.png" alt="Soybean pangenome analysis figure from published study" width=70% height=70% caption="https://doi.org/10.1016/j.cell.2020.05.023" >}}
 
 Overall, genome projects vary greatly in difficulty, reflecting the diverse DNA structures of different organisms. Some organisms are easier to sequence and assemble, such as the Fugu with its relatively small genome, or the Anopheles mosquito with simpler chromosomes. On the other hand, some organisms such as the axolotl have extremely large genomes, while organisms like platypuses have unique chromosomal structures.
 
-{{< figure src="/notes/genomics/img/projects.png" width=70% height=70% >}}
+{{< figure src="/notes/genomics/img/projects.png" alt="Overview of current genomics and pangenome project initiatives" caption="Examples of genomics project efforts" width=70% height=70% >}}

--- a/content/notes/genomics/7-1-busco.md
+++ b/content/notes/genomics/7-1-busco.md
@@ -10,9 +10,9 @@ menu:
 
 __BUSCO__ (Benchmarking Universal Single-Copy Orthologs) is a tool used to assess the completeness of genome assemblies and annotations. It does this by looking for single-copy orthologs in the DNA sequence.
 
-{{< figure src="/notes/genomics/img/busco1.png" width=70% height=70% caption="BUSCO assessment workflow and relative run-times" >}}
+{{< figure src="/notes/genomics/img/busco1.png" alt="BUSCO assessment workflow diagram with relative run times" width=70% height=70% caption="BUSCO assessment workflow and relative run-times" >}}
 
-{{< figure src="/notes/genomics/img/busco2.png" width=50% height=50% caption="Key properties of BUSCO's benchmark orthologs" >}}
+{{< figure src="/notes/genomics/img/busco2.png" alt="Summary of key properties of BUSCO benchmark ortholog sets" width=50% height=50% caption="Key properties of BUSCO's benchmark orthologs" >}}
 
 ## Running Busco Interactively
 
@@ -111,7 +111,7 @@ sbatch busco_slurm_submit.sh
 
 When you run a Slurm script with the `#SBATCH --mail-user=yourid@virginia.edu` line and `#SBATCH --mail-type=ALL` line, Slurm will send you email notifications when your job starts, stops, or fails.
 
-{{< figure src="/notes/genomics/img/email.png" width=70% height=70% caption="Slurm email examples" >}}
+{{< figure src="/notes/genomics/img/email.png" alt="Example Slurm job notification emails" width=70% height=70% caption="Slurm email examples" >}}
 
 To immediately monitor the status of your Slurm job, enter:
 
@@ -128,7 +128,7 @@ BUSCO is used to measure the completeness of a genome assembly. To measure the c
 
 To calculate the N50 value for a genome, we place our contigs from largest to smallest on the genome. We then start with the longest contig and add the lengths of the next configs until the cumulative length reaches at least 50% of the total genome size. The length of the shortest contig added is the N50 value.
 
-{{< figure src="/notes/genomics/img/n50.png" width=50% height=50% >}}
+{{< figure src="/notes/genomics/img/n50.png" alt="N50 metric diagram for evaluating assembly contiguity" caption="N50 assembly quality metric" width=50% height=50% >}}
 
 The N50 value is then compared with N50 values from genomes of similar size. A greater N50 is usually a sign of assembly improvement. Keep in mind that genome composition can bias comparisons. Another metric used alongside N50 is __L50__, which is the number of contigs that make up the N50. For example, a highly-contiguous assembly will have a high N50 value and a low L50 value.
 

--- a/content/notes/genomics/7-2-repeatmasker.md
+++ b/content/notes/genomics/7-2-repeatmasker.md
@@ -12,7 +12,7 @@ Repetitive DNA sequences (biased nucleotide composition, tandem repeats, dispers
 
 RepeatMasker uses two types of masking: soft and hard. Soft masking indicates masked regions by using lower-case letters. Hard masking (indicated with the `-hardmask` option) overwrites masked regions with a wildcard letter, using `N` for nucleotides or X for proteins.
 
-{{< figure src="/notes/genomics/img/repeatmaskerex.png" width=50% height=50% caption="RepeatMasker masking example" >}}
+{{< figure src="/notes/genomics/img/repeatmaskerex.png" alt="Example showing how RepeatMasker masks repetitive sequence regions" width=50% height=50% caption="RepeatMasker masking example" >}}
 
 RepeatMasker is able to generate detailed annotations of the repeats in the DNA sequence, as well as a modified version of the DNA sequence in which all the annotated repeats have been masked (by default, replaced by `N`s). Masking tools play a huge part in genomics research; for example, currently over 56% of the human genomic sequence is identified and masked by these programs.
 
@@ -46,7 +46,7 @@ RepeatMasker genome_raw.fasta -lib Muco_library_EDTA.fasta -gff
 
 After running the Slurm job, your output files will include masked sequence files, repeat statistics tables and `.gff` files.
 
-{{< figure src="/notes/genomics/img/repeatmaskerstats.png" width=50% height=50% caption="RepeatMasker output example" >}}
+{{< figure src="/notes/genomics/img/repeatmaskerstats.png" alt="RepeatMasker output statistics summary" width=50% height=50% caption="RepeatMasker output example" >}}
 
 For more info on RepeatMasker:  
 https://www.repeatmasker.org/

--- a/content/notes/genomics/7-3-stringtie.md
+++ b/content/notes/genomics/7-3-stringtie.md
@@ -58,7 +58,7 @@ To check if your permissions are set to run StringTie, use the `ls -lh` command:
 ls -lh stringtie
 ```
 
-{{< figure src="/notes/genomics/img/permissions.png" width=60% height=60% caption="How to read file permission settings from example output" >}}
+{{< figure src="/notes/genomics/img/permissions.png" alt="Example terminal output used to explain Unix file permission settings" width=60% height=60% caption="How to read file permission settings from example output" >}}
 
 ## Running StringTie
 

--- a/content/notes/genomics/7-4-smrtlink.md
+++ b/content/notes/genomics/7-4-smrtlink.md
@@ -24,7 +24,7 @@ module load smrtlink/25.2.0
 
 The SMRT Link software suite includes *lots* of tools available for sequence analysis and manipulation, such as `bam2fasta`, `bam2fastq`, `blasr`, `pbmm`, `pbalign`, and `isoseq3`.
 
-{{< figure src="/notes/genomics/img/smrtlink.png" width=60% height=60% >}}
+{{< figure src="/notes/genomics/img/smrtlink.png" alt="SMRT Link interface used for PacBio sequence analysis" caption="SMRT Link interface" width=60% height=60% >}}
 
 For more info on SMRT Link:
 https://docslib.org/doc/175362/smrt%C2%AE-tools-reference-guide-v8-0


### PR DESCRIPTION
This PR adds descriptive alt text to images in the following tutorials:
- Introduction to Bioinformatic Tools for HPC
- Working with Genomic Data on HPC

These changes address accessibility issues identified during review and ensure that images are accessible to screen readers.
All images were updated with meaningful alt text to improve usability for assistive technologies. No functional changes were made.