### PR TITLE
accessibility changes for LLMs on HPC tutorial

### DIFF
--- a/content/notes/llms-hpc/fine-tuning/fine-tuning-intro.md
+++ b/content/notes/llms-hpc/fine-tuning/fine-tuning-intro.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_10.png width=70% height=70% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_10.png alt="Workflow diagram showing raw text data used for pre-training, then fine-tuning with a custom knowledge base to produce a fine-tuned LLM." width=70% height=70% >}}
 
 LLMs are pre-trained on huge amounts of text data to learn general language patterns.
 

--- a/content/notes/llms-hpc/fine-tuning/hf-trainer-class.md
+++ b/content/notes/llms-hpc/fine-tuning/hf-trainer-class.md
@@ -13,7 +13,7 @@ The Trainer class allows a user to train or fine-tune a model using a convenient
 When training, the Trainer will automatically use the GPU if one is present.
 
 There are  __many__ options that can be set for the TrainingArguments (number of epochs, learning rate, save strategy, etc).
-  * [More TrainingArguments](https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments)
+  * [Hugging Face TrainingArguments documentation](https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments)
 
 The Trainer will not automatically evaluate the LLM, so we will pass it an evaluation metric.
 

--- a/content/notes/llms-hpc/fine-tuning/selecting-gpu-ft.md
+++ b/content/notes/llms-hpc/fine-tuning/selecting-gpu-ft.md
@@ -23,8 +23,8 @@ A training iteration requires a forward and backward pass of the model. In addit
 According to the [Hugging Face Model Memory Calculator](https://huggingface.co/spaces/hf-accelerate/model-memory-usage), for a batch size of 1,  $$ \text{GPU Memory Estimate for Fine-Tuning (B)} = 4 \times (\text{LLM Memory in B})$$ 
   * While this formula can help ballpark an estimate, I recommend tracking GPU memory using the GPU Dashboard to make a more informed GPU selection.
 
-For a more specific formula, see [https://blog.eleuther.ai/transformer-math/](https://blog.eleuther.ai/transformer-math/) (Note: this blog requires some understanding of transformers).
+For a more specific formula, see the [EleutherAI transformer math overview](https://blog.eleuther.ai/transformer-math/) (note: this blog requires some understanding of transformers).
 
 
-Determining LLM memory for fine-tuning is an active area of research.  The paper [LLMem](https://arxiv.org/abs/2404.10933)[: Estimating GPU Memory Usage for Fine-Tuning Pre-Trained LLMs](https://arxiv.org/abs/2404.10933) by Kim, et al. (April 2024) presents a method for doing so within 3% of the actual memory required.
+Determining LLM memory for fine-tuning is an active area of research. The paper [LLMem: Estimating GPU Memory Usage for Fine-Tuning Pre-Trained LLMs](https://arxiv.org/abs/2404.10933) by Kim et al. (April 2024) presents a method for doing so within 3% of the actual memory required.
 

--- a/content/notes/llms-hpc/fine-tuning/why-use-ft.md
+++ b/content/notes/llms-hpc/fine-tuning/why-use-ft.md
@@ -8,7 +8,7 @@ menu:
         parent: Fine-Tuning
 ---
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_11.png width=65% height=65% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_11.png alt="Comparison diagram showing pre-training on a large unlabeled dataset as computationally demanding and fine-tuning on a small labeled dataset as computationally inexpensive." width=65% height=65% >}}
 
 
 Fine-tuning builds on a pre-trained language model (LLM) by using a smaller, labeled dataset to specialize and improve its performance for a specific task. Pre-training requires a large dataset and is computationally demanding, but fine-tuning is much less resource-intensive and allows models to adapt to domain-specific needs efficiently.
@@ -16,9 +16,9 @@ Fine-tuning builds on a pre-trained language model (LLM) by using a smaller, lab
 
 Example:
 
-[distilbert](https://huggingface.co/distilbert/distilbert-base-uncased)[/](https://huggingface.co/distilbert/distilbert-base-uncased)[distilbert](https://huggingface.co/distilbert/distilbert-base-uncased)[-base-uncased](https://huggingface.co/distilbert/distilbert-base-uncased) was pre-trained on [BookCorpus](https://huggingface.co/datasets/bookcorpus/bookcorpus) and [English Wikipedia](https://huggingface.co/datasets/legacy-datasets/wikipedia), ~25GB of data
+The model [distilbert-base-uncased](https://huggingface.co/distilbert/distilbert-base-uncased) was pre-trained on [BookCorpus](https://huggingface.co/datasets/bookcorpus/bookcorpus) and [English Wikipedia](https://huggingface.co/datasets/legacy-datasets/wikipedia), about 25 GB of data.
 
-[distilbert](https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english)[/distilbert-base-uncased-finetuned-sst-2-english ](https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english)was fine-tuned on [Stanford Sentiment Treebank (sst2)](https://huggingface.co/datasets/stanfordnlp/sst2), ~5MB of data
+The model [distilbert-base-uncased-finetuned-sst-2-english](https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english) was fine-tuned on the [Stanford Sentiment Treebank (SST-2)](https://huggingface.co/datasets/stanfordnlp/sst2), about 5 MB of data.
 
 
 

--- a/content/notes/llms-hpc/hpc-resources-llms/gpu-dashboard.md
+++ b/content/notes/llms-hpc/hpc-resources-llms/gpu-dashboard.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_5.png width=50% height=50% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_5.png alt="GPU Dashboard menu listing Machine Resources, GPU Utilization, GPU Memory, GPU Resources, PCIe Throughput, NVLink Throughput, and NVLink Timeline." width=50% height=50% >}}
 
 The GPU Dashboard is included in OOD (Open On Demand). It checks CPU and GPU efficiency. This will be demoed during the exercises in this workshop.
 

--- a/content/notes/llms-hpc/hpc-resources-llms/memory-usage-gpu.md
+++ b/content/notes/llms-hpc/hpc-resources-llms/memory-usage-gpu.md
@@ -25,12 +25,12 @@ os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
 
 ```
 
-[More Info](https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth)
+[TensorFlow guide to limiting GPU memory growth](https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth)
 
 Homework for Keras users: try out GPU dashboard and see if it reports all of the GPU memory as used.
 
 
-### Resource Allocation for LLMs
+## Resource Allocation for LLMs
 
 
 Resource needs will vary based on LLM use (inference, fine-tuning, etc.)

--- a/content/notes/llms-hpc/hpc-resources-llms/queue-wait.md
+++ b/content/notes/llms-hpc/hpc-resources-llms/queue-wait.md
@@ -13,7 +13,7 @@ You may not need to request an A100 GPU!
 
 Requesting an A100 may mean you wait in the queue for a much longer time than using another GPU. This could give you a slower overall time (wait time + execution time) than if you had used another GPU.
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_4.png width=90% height=90% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_4.png alt="Three plots showing that queue time rises with more allocated resources, execution time falls, and total time to solution is minimized at an intermediate resource level." width=90% height=90% >}}
 
 **When you request memory for HPC, that is CPU memory.**
 

--- a/content/notes/llms-hpc/inference/exercise_3c.md
+++ b/content/notes/llms-hpc/inference/exercise_3c.md
@@ -13,7 +13,7 @@ menu:
 As ```batch_size``` increases, so does GPU memory usage.
 If you get an OOM (out of memory) error while using the GPU, try decreasing the LLM batch size.
 
-[Source and more information](https://huggingface.co/docs/transformers/en/main_classes/pipelines#pipeline-batching)
+[Hugging Face pipeline batching documentation](https://huggingface.co/docs/transformers/en/main_classes/pipelines#pipeline-batching)
 
 
 ## Exercise 3c: Batch Size and Num Workers - Text Summarization

--- a/content/notes/llms-hpc/inference/exercise_4.md
+++ b/content/notes/llms-hpc/inference/exercise_4.md
@@ -10,7 +10,7 @@ menu:
 
 ## Select a GPU for Inference
 
-Suppose you are going to run inference using the model [google-](https://huggingface.co/google-bert/bert-base-uncased)[bert](https://huggingface.co/google-bert/bert-base-uncased)[/](https://huggingface.co/google-bert/bert-base-uncased)[bert](https://huggingface.co/google-bert/bert-base-uncased)[-base-uncased](https://huggingface.co/google-bert/bert-base-uncased).  Which UVA GPU would you select and why?
+Suppose you are going to run inference using the model [google-bert/bert-base-uncased](https://huggingface.co/google-bert/bert-base-uncased). Which UVA GPU would you select and why?
 
 | UVA GPU | Full Name | Year Launched | Memory | # of Tensor Cores |
 | :-: | :-: | :-: | :-: | :-: |

--- a/content/notes/llms-hpc/inference/transformers-pipeline.md
+++ b/content/notes/llms-hpc/inference/transformers-pipeline.md
@@ -24,6 +24,6 @@ The pipeline "hides" details from the programmer, which can be good and bad.
 
 The tokenizer runs on CPU, and the model runs on GPU.
 
-[Source and more information](https://huggingface.co/docs/transformers/pipeline_tutorial)
+[Hugging Face transformers pipeline tutorial](https://huggingface.co/docs/transformers/pipeline_tutorial)
 
 

--- a/content/notes/llms-hpc/inference/using-llm.md
+++ b/content/notes/llms-hpc/inference/using-llm.md
@@ -13,9 +13,9 @@ LLMs can be used as-is (i.e., out-of-the-box) or after fine-tuning.
 Hugging Face model cards will generally provide code for how to get started.
 Code may be PyTorch or TensorFlow, “raw” (using the model directly), or pipeline code (using the pipeline from transformers library).
 
-  * [Ex 1](https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english)
+  * [DistilBERT sentiment analysis example](https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english)
     * provides “raw” PyTorch code
-  * [Ex 2](https://huggingface.co/facebook/bart-large-cnn)
+  * [BART summarization example](https://huggingface.co/facebook/bart-large-cnn)
     * provides pipeline code
 
 Code for at least loading the model (directly and using the pipeline) is provided by clicking the “Use this model” button on Hugging Face. You may have to dig through the links to find the code you need.

--- a/content/notes/llms-hpc/inference/what-is-inference.md
+++ b/content/notes/llms-hpc/inference/what-is-inference.md
@@ -12,7 +12,7 @@ menu:
 __Inference__  is the process in which a trained (or fine-tuned) LLM makes a prediction for a given input.
 
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_9.png height=90% width=90% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_9.png alt="Inference diagram showing a prompt phase followed by decode iterations that generate tokens one at a time until EOS." height=90% width=90% >}}
 
 EOS: end of sequence
 

--- a/content/notes/llms-hpc/llm-overview/llm-overview.md
+++ b/content/notes/llms-hpc/llm-overview/llm-overview.md
@@ -16,7 +16,7 @@ There are many different types of LLMs that are suited to particular tasks.
 
 Hubs such as [Hugging Face](https://huggingface.co/) provide many LLMs for download.
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_0.png height=90% width=90% caption="Graphic Source: [https://attri.ai/blog/introduction-to-large-language-models](https://attri.ai/blog/introduction-to-large-language-models)" >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_0.png alt="Diagram showing text input entering a language model and producing either text output or a numeric representation." height=90% width=90% caption="Graphic source: [Introduction to large language models article on attri.ai](https://attri.ai/blog/introduction-to-large-language-models)" >}}
 
 
 You may hear people talk about LLMs for image classification, computer vision, etc.  These are also called VLMs (vision language models) and we are not covering those today.

--- a/content/notes/llms-hpc/llm-overview/nlp-problems.md
+++ b/content/notes/llms-hpc/llm-overview/nlp-problems.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_1.png height=75% width=75% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_1.png alt="Diagram showing NLP tasks solved by LLMs: search, classify, cluster, summarize, generate, rewrite, and extract." height=75% width=75% >}}
 
 __Problems:__
 

--- a/content/notes/llms-hpc/llm-overview/theory-llms.md
+++ b/content/notes/llms-hpc/llm-overview/theory-llms.md
@@ -8,13 +8,13 @@ menu:
       parent: Overview of LLMs
 ---
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_2.png height=50% width=50% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_2.png alt="Transformer architecture diagram with encoder and decoder stacks, multi-head attention, feed-forward layers, and output probabilities." height=50% width=50% >}}
 
 LLMs are based on the transformer architecture.
 We are not covering this in today’s workshop.
 
 More Information:
   * _[Attention Is All You Need](https://arxiv.org/abs/1706.03762)_ by Vaswani et al. (2017)
-  * [https://jalammar.github.io/illustrated-transformer/](https://jalammar.github.io/illustrated-transformer/)
+  * [The Illustrated Transformer overview by Jay Alammar](https://jalammar.github.io/illustrated-transformer/)
 
 

--- a/content/notes/llms-hpc/model-selection/choosing-hf.md
+++ b/content/notes/llms-hpc/model-selection/choosing-hf.md
@@ -19,7 +19,7 @@ If you need to fine-tune a model, do you have the computational resources to do 
   
 Larger models (i.e., models with more parameters) will need more resources.
 
-[Source and more information](https://medium.com/@harshapulletikurti/choosing-the-correct-llm-model-from-hugging-face-hub-183fc6198295)
+[Guide to choosing the correct Hugging Face Hub LLM model](https://medium.com/@harshapulletikurti/choosing-the-correct-llm-model-from-hugging-face-hub-183fc6198295)
 
 
 ## Choosing the Model
@@ -38,5 +38,5 @@ Read model card (documentation), including
   * Any benchmarking results.
 
 
-[Source and more information](https://medium.com/@harshapulletikurti/choosing-the-correct-llm-model-from-hugging-face-hub-183fc6198295)
+[Guide to choosing the correct Hugging Face Hub LLM model](https://medium.com/@harshapulletikurti/choosing-the-correct-llm-model-from-hugging-face-hub-183fc6198295)
 

--- a/content/notes/llms-hpc/model-selection/finding-model-size.md
+++ b/content/notes/llms-hpc/model-selection/finding-model-size.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_7.png height=80% width=80% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_7.png alt="Hugging Face model card for facebook slash bart-large-cnn showing task tags, downloads, and model size information." height=80% width=80% >}}
 
 Use the information on the model card.
 
@@ -17,7 +17,7 @@ $$ \text{Model Size (B)} = \text{(Number of parameters)} \times \text{(bytes/par
 
 ---
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_8.png height=60% width=60% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_8.png alt="Hugging Face Files and versions tab for facebook slash bart-large-cnn showing model files such as pytorch_model.bin and their sizes." height=60% width=60% >}}
 
 Use information on the Files and versions tab.
 

--- a/content/notes/llms-hpc/model-selection/model-selection.md
+++ b/content/notes/llms-hpc/model-selection/model-selection.md
@@ -10,5 +10,5 @@ menu:
 ---
 
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_6.png height=50% width=50% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_6.png alt="Hugging Face logo." height=50% width=50% >}}
 

--- a/content/notes/llms-hpc/setup/ood.md
+++ b/content/notes/llms-hpc/setup/ood.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_3.png height=70% width=70% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_3.png alt="Open OnDemand JupyterLab notebook launcher showing available kernels such as Python 3, PyTorch 2.4.0, RAPIDS, and TensorFlow 2.13.0." height=70% width=70% >}}
 
 Click on the kernel to open a Jupyter Notebook.
 

--- a/content/notes/llms-hpc/slurm-scripts/options-slurm.md
+++ b/content/notes/llms-hpc/slurm-scripts/options-slurm.md
@@ -14,7 +14,7 @@ menu:
 
 Units are given with a suffix (K, M, G, or T).  If no unit is given, megabytes is assumed.
 
-Other options are available at [https://slurm.schedmd.com/sbatch.html](https://slurm.schedmd.com/sbatch.html)
+Additional sbatch options are documented in the [Slurm sbatch reference](https://slurm.schedmd.com/sbatch.html).
 
 For more information, see the RC tutorial [Using SLURM from a Terminal](https://learning.rc.virginia.edu/tutorials/slurm-from-cli/).
 

--- a/content/notes/llms-hpc/slurm-scripts/slurm-ex.md
+++ b/content/notes/llms-hpc/slurm-scripts/slurm-ex.md
@@ -44,6 +44,6 @@ The default command defined in each container is “python” so using “run”
 
 The load software and run code lines are what a user would use to run their script at the command line.
 
-[TensorFlow example](https://www.rc.virginia.edu/userinfo/rivanna/software/tensorflow/#tensorflow-slurm-jobs) 
+[TensorFlow Slurm job example](https://www.rc.virginia.edu/userinfo/rivanna/software/tensorflow/#tensorflow-slurm-jobs)
 
 

--- a/content/notes/llms-hpc/wrap-up/more-help.md
+++ b/content/notes/llms-hpc/wrap-up/more-help.md
@@ -15,8 +15,8 @@ Tuesdays:       	3 pm - 5 pm
 
 Thursdays:     	10 am - noon
 
-Zoom Links are available at https://www.rc.virginia.edu/support/#office-hours
+Zoom links are available on the [Research Computing office hours page](https://www.rc.virginia.edu/support/#office-hours).
 
-[RC Website](https://rc.virginia.edu)
+[UVA Research Computing website](https://rc.virginia.edu)
 
 

--- a/content/notes/llms-hpc/wrap-up/recap.md
+++ b/content/notes/llms-hpc/wrap-up/recap.md
@@ -20,9 +20,9 @@ menu:
 
 ## Research Computing Data Analytics Center
 
-{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_13.png width=80% height=80% >}}
+{{< figure src=/notes/llms-hpc/img/LLMS_on_HPC_13.png alt="Banner announcing UVA's Data Analytics Center as a new resource supporting researchers with large dataset management and analysis." width=80% height=80% >}}
 
-[https://www.rc.virginia.edu/service/dac/](https://www.rc.virginia.edu/service/dac/)
+[Research Computing Data Analytics Center service page](https://www.rc.virginia.edu/service/dac/)
 
 
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -126,7 +126,7 @@
     <ul class="nav-icons navbar-nav flex-row ml-auto d-flex pl-md-2">
       {{ if site.Params.search.engine }}
       <li class="nav-item">
-        <a class="nav-link js-search" href="#" title="Search the site"><i class="fas fa-search" aria-hidden="true"></i></a>
+        <a class="nav-link js-search" href="#" title="Search the site" aria-label="Search"><i class="fas fa-search" aria-hidden="true"></i></a>
       </li>
       {{ end }}
 

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -5,7 +5,7 @@
 
       <div class="row no-gutters justify-content-between mb-3">
         <div class="col-6">
-          <h1 id="search-title">{{ i18n "search" }}</h1>
+          <h2 id="search-title">{{ i18n "search" }}</h2>
         </div>
         <button type="button" class="js-search close-search-btn" aria-label="Close search">
           <i class="fas fa-times-circle text-muted" aria-hidden="true"></i>
@@ -30,12 +30,14 @@
 
     <div class="section-search-results">
 
-      <div id="search-result-count" aria-live="assertive" aria-atomic="true">
+      <div id="search-results" aria-live="polite" aria-atomic="true">
+        <div id="search-result-count">
         <!-- Result count heading will appear here and be announced by screen readers -->
-      </div>
+        </div>
 
-      <div id="search-hits">
-        <!-- Search results will appear here -->
+        <div id="search-hits">
+          <!-- Search results will appear here -->
+        </div>
       </div>
 
     </div>


### PR DESCRIPTION
This PR improves accessibility for the LLMs on HPC notes by adding alt text to images, making link text clearer, and fixing heading order. It also improves the search dialog for screen readers.