### PR TITLE
fix: WCAG 2.2 AA accessibility fixes for uva-rc-genai workshop

### DIFF
--- a/content/notes/uva-rc-genai/usage/access.md
+++ b/content/notes/uva-rc-genai/usage/access.md
@@ -14,8 +14,7 @@ menu:
 ## How to Login
 Below are the first steps needed for all users regardless of access method:
 
-<div style="background-color: #dc3545; border-left: 4px solid
-  #2196F3; padding: 12px; margin: 16px 0;">
+<div role="note" style="background-color: #dc3545; border-left: 4px solid #2196F3; padding: 12px; margin: 16px 0;">
   <strong>Note:</strong> Accessing UVA RC GenAI requires an active UVA computing
   ID, research computing account and EServices password for Netbadge
   authentication. Duo two-factor authentication is required for

--- a/content/notes/uva-rc-genai/usage/api.md
+++ b/content/notes/uva-rc-genai/usage/api.md
@@ -43,8 +43,7 @@ You will have the option to view, copy or create a new API key.
 Use environment variables to safely store your key (e.g., `export UVARC_GenAI_API="your-key-here"`). Make sure to never commit keys to code repositories, and regenerate keys in UVA RC GenAI browser if compromised.
 
 
-<div style="background-color: #dc3545; border-left: 4px solid
-  #2196F3; padding: 12px; margin: 16px 0;">
+<div role="note" style="background-color: #dc3545; border-left: 4px solid #2196F3; padding: 12px; margin: 16px 0;">
   <strong>Note:</strong> You need to be on a compute node to run your code.
 </div>
 

--- a/content/notes/uva-rc-genai/usage/browser.md
+++ b/content/notes/uva-rc-genai/usage/browser.md
@@ -19,10 +19,9 @@ Here, you can chat through the conversational interface, adjust integrations (e.
 
 Files can be loaded into the web interface – supported extensions include: pdf, docx, txt, md, csv, png, jpeg, jpg, pptx, xls, xlsx, json, sh, html, htm, xhtml, js, and py.
 
-<div style="background-color: #dc3545; border-left: 4px solid
-  #2196F3; padding: 12px; margin: 16px 0;">
+<div role="note" style="background-color: #dc3545; border-left: 4px solid #2196F3; padding: 12px; margin: 16px 0;">
   <strong>Note:</strong> Chats are not saved. Conversation history disappears
   when you close the browser tab, sign out, or if the session expires.
 </div>
 
-More on data management will be discussed [later](/notes/uva-rc-genai/usage/data_management).
+More on data management will be discussed in the [Data Management](/notes/uva-rc-genai/usage/data_management) section.

--- a/content/notes/uva-rc-genai/usage/data_management.md
+++ b/content/notes/uva-rc-genai/usage/data_management.md
@@ -24,7 +24,7 @@ The "Copy" option copies only prompts, responses and reasonings, similar to what
 
 ## Storage Options
 Downloaded browser chats will be saved to your local workstation but can be easily copied to HPC storage. If you're saving chats on HPC storage it's important to remember the limitations and use cases for each of RCs storage options.
-See [here](https://www.rc.virginia.edu/userinfo/hpc/storage/) for details on our complementary storage options and [here](https://www.rc.virginia.edu/userinfo/storage/) for leased options. 
+See [RC complementary storage options](https://www.rc.virginia.edu/userinfo/hpc/storage/) for details, and [RC leased storage options](https://www.rc.virginia.edu/userinfo/storage/) for leased options. 
 
 ## Reproducibility Considerations
 Reproducibility controls are important since LLM outputs can vary across different runs. This makes it impossible to verify results, replicate research, or trace back errors. The following are some important considerations regarding output reproducibility.

--- a/content/notes/uva-rc-genai/usage/jupyter_notebooks.md
+++ b/content/notes/uva-rc-genai/usage/jupyter_notebooks.md
@@ -14,7 +14,7 @@ menu:
 ## Jupyter Notebook Workflow
 UVA RC GenAI can be accessed from a Jupyter notebook using the python API client to integrate LLM capabilites for data analysis, code generation, and automated research workflows. 
 
-Download this [ZIP file](https://www.rc.virginia.edu/data/LLM_API_Example.zip) for a Jupyter notebook reference. 
+Download the [LLM API Example Jupyter Notebook (ZIP)](https://www.rc.virginia.edu/data/LLM_API_Example.zip) for a reference notebook. 
 
 ## Research Use Cases
 

--- a/content/notes/uva-rc-genai/usage/service_overview.md
+++ b/content/notes/uva-rc-genai/usage/service_overview.md
@@ -14,8 +14,8 @@ menu:
 UVA RC Gen AI is available exclusively to users with active [Research Computing accounts](https://www.rc.virginia.edu/userinfo/hpc/access/). It's accessible via both a chat-like browser interface and API within standard security zone systems (Afton/Rivanna).  
 
 ## Where can I Access UVA RC GenAI from?
-* **On grounds**: Direct browser access is available. API access must run from a standard security zone HPC node. See [here](https://www.rc.virginia.edu/userinfo/hpc/login/) for HPC access methods.
+* **On grounds**: Direct browser access is available. API access must run from a standard security zone HPC node. See [HPC access methods](https://www.rc.virginia.edu/userinfo/hpc/login/) for details.
 
 * **Off grounds**: VPN is required for browser access and access to HPC nodes.
 
-Additional details can be found in our [user guide](https://www.rc.virginia.edu/userinfo/rcgenai-userguide/), and support resources can be found [here](https://www.rc.virginia.edu/support/) on our website. 
+Additional details can be found in our [user guide](https://www.rc.virginia.edu/userinfo/rcgenai-userguide/), and [support resources](https://www.rc.virginia.edu/support/) can be found on our website. 

--- a/content/notes/uva-rc-genai/usage/vocab.md
+++ b/content/notes/uva-rc-genai/usage/vocab.md
@@ -13,7 +13,7 @@ menu:
 
 The following are common terms used when working with UVA RC GenAI and LLMs in general.
 
-### Core Units
+## Core Units
 
 * **Token** - The basic unit of text LLMs process. Can be a whole word, part of a word, or a single character. Roughly 100 tokens ≈ 75 words. All usage, limits, and costs are measured in tokens.
 
@@ -21,19 +21,19 @@ The following are common terms used when working with UVA RC GenAI and LLMs in g
 
 * **System Prompt** - A hidden prompt that sets the model's behavior rules for the entire conversation—such as tone, role, or safety constraints. It frames how the model interprets all subsequent user prompts.
 
-### Capacity Limits
+## Capacity Limits
 
 * **Context Window** - The maximum number of tokens (input + output combined) a model can consider at one time. 
 
 * **Batched Token Length** - The total tokens across multiple requests sent together as a single batch. Batching can improve efficiency; this is the sum of all tokens in that group.
 
-### Generation Parameters (API access only)
+## Generation Parameters (API access only)
 
 * **Temperature** - Controls output randomness. Lower values (0.1-0.3) produce more focused, deterministic responses; higher values (0.8-1.0) produce more varied and creative outputs.
 
 * **Seed** - An integer that initializes the random number generator. Using the same seed with identical prompts and settings produces reproducible outputs.
 
-### Usage and Operations
+## Usage and Operations
 
 * **Metadata** - Non-content information about an API exchange: timestamp, model version, token counts, request ID, cost.
 


### PR DESCRIPTION
Replaced vague link text ("here", "later") with descriptive text across 4 files (WCAG 2.4.4)
Added role="note" to callout divs in 3 files (WCAG 1.3.1, 4.1.2)
Fixed H1→H3 heading skip in vocab.md by promoting 4 headings from ### to ## (WCAG 1.3.1)
Improved download link text in jupyter_notebooks.md to name the file and type (WCAG 2.4.4)